### PR TITLE
fix the unable to handle request for v1.26

### DIFF
--- a/metrics-server-deployment.yaml
+++ b/metrics-server-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         k8s-app: metrics-server
     spec:
+      hostNetwork: true
       serviceAccountName: metrics-server
       volumes:
       # mount in tmp so we can safely use from-scratch images and/or read-only containers


### PR DESCRIPTION
Error from server (ServiceUnavailable): the server is currently unable to handle the request (get nodes.metrics.k8s.io)